### PR TITLE
Debugging features

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Automated UI regression testing for the Decent webapp using Selenium WebDriver a
 |---------|-------------|
 | `npm test` | Run all tests for all governance types |
 | `npm run test:debug` | Quick test (5 tests per governance type) |
+| `npm run test:debug-mode` | Enable comprehensive debug logging |
+| `npm run test:debug-verbose` | Debug mode with verbose logging |
 | `npm run test:multisig` | Run only multisig tests |
 | `npm run test:erc20` | Run only ERC20 token voting tests |
 | `npm run test:erc721` | Run only ERC721 NFT voting tests |
@@ -47,8 +49,30 @@ npm test -- --debug --env=release --governance=erc20
 | `--file=` | `tests/path/to/file.test.ts` | Run a single test file |
 | `--env=` | `production`, `release` | Environment (default: `develop`) |
 | `--base-url=` | Any URL | Override environment with custom URL |
-| `--flags=` | `feature_1=on,debug=on` | Pass feature flags as URL parameters |
+| `--flags=` | `feature_1=on,flag_debug=on` | Pass feature flags as URL parameters |
 | `--no-headless` | (flag) | Disable headless mode; run test in chrome tab |
+| `--debug-mode` | (flag) | Enable comprehensive debug logging and analysis |
+
+### Debug Mode
+
+Enable comprehensive test debugging with structured logs, screenshots, and DOM snapshots:
+
+```bash
+# Enable debug mode
+npm test -- --debug-mode
+
+# Configure debug options
+npm test -- --debug-mode --debug-level=verbose --debug-screenshots=true
+```
+
+**Debug CLI Arguments:**
+- `--debug-mode` - Enable debug logging and analysis
+- `--debug-level=verbose|detailed|minimal` - Set logging detail level  
+- `--debug-screenshots=true|false` - Capture debug screenshots (default: true)
+- `--debug-dom-snapshots=true|false` - Capture DOM snapshots (default: true)
+- `--debug-format=json|structured-text` - Output format (default: structured-text)
+
+Debug output is saved to `test-results/debug-logs/` with AI-parseable structured logs.
 
 ## Configuration
 
@@ -64,10 +88,15 @@ npm test -- --debug --env=release --governance=erc20
 tests/
 ├── general/            # Cross-governance tests (app navigation, DAO creation)
 ├── multisig/           # Multi-signature governance tests
-└── token-voting/       # ERC20/ERC721 governance tests  
+└── token-voting/       # ERC20/ERC721 governance tests
+
+src/
+└── debug/              # Debug logging and analysis tools (includes example test)
 
 config/                 # Test configuration
 test-results/           # Generated reports and screenshots
+├── debug-logs/         # Debug mode output (when enabled)
+└── screenshots/        # Test completion screenshots
 ```
 
 ## Development
@@ -81,4 +110,5 @@ test-results/           # Generated reports and screenshots
 - Screenshots automatically captured on test completion  
 - HTML and Markdown reports generated for all runs
 - Cross-platform support (Windows, macOS, Linux)
+- **Debug Mode**: Comprehensive test debugging with structured logs, DOM snapshots, and AI-parseable output for efficient failure analysis
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,12 @@
     "test:multisig": "ts-node src/run-tests.ts --governance=multisig",
     "test:production": "ts-node src/run-tests.ts --env=production",
     "test:release": "ts-node src/run-tests.ts --env=release",
-    "test:debug": "ts-node src/run-tests.ts --debug"
+    "test:debug": "ts-node src/run-tests.ts --debug",
+    "test:debug-mode": "ts-node src/run-tests.ts --debug-mode",
+    "test:debug-verbose": "ts-node src/run-tests.ts --debug-mode --debug-level=verbose",
+    "test:debug-erc20": "ts-node src/run-tests.ts --governance=erc20 --debug-mode",
+    "test:debug-multisig": "ts-node src/run-tests.ts --governance=multisig --debug-mode",
+    "test:debug-single": "ts-node src/run-tests.ts --single --debug-mode"
   },
   "dependencies": {
     "selenium-webdriver": "^4.0.0"

--- a/src/debug/debug-config.ts
+++ b/src/debug/debug-config.ts
@@ -17,8 +17,11 @@ export class DebugConfigManager {
   private config: DebugConfig;
 
   private constructor() {
-    // Check for debug mode activation via CLI argument
-    const isDebugEnabled = process.argv.includes('--debug-mode');
+    // Check for debug toolset activation via --debug-mode flag
+    // npm passes --debug-mode as --debug_mode in process.argv and as npm_config_debug_mode in env
+    const isDebugEnabled = process.argv.includes('--debug-mode') || 
+                          process.argv.includes('--debug_mode') ||
+                          process.env.npm_config_debug_mode === 'true';
 
     this.config = {
       enabled: isDebugEnabled,
@@ -70,19 +73,47 @@ export class DebugConfigManager {
 
   /**
    * Get the value of a CLI argument (e.g., --debug-level=verbose)
+   * Handles both hyphen and underscore formats, plus npm environment variables
    */
   private getCliArgValue(argName: string): string | undefined {
+    // Try hyphen format
     const argWithEquals = `${argName}=`;
-    const arg = process.argv.find(arg => arg.startsWith(argWithEquals));
-    return arg ? arg.split('=')[1] : undefined;
+    let arg = process.argv.find(arg => arg.startsWith(argWithEquals));
+    if (arg) return arg.split('=')[1];
+    
+    // Try underscore format (npm converts hyphens to underscores)
+    const underscoreArgName = argName.replace(/-/g, '_');
+    const underscoreArgWithEquals = `${underscoreArgName}=`;
+    arg = process.argv.find(arg => arg.startsWith(underscoreArgWithEquals));
+    if (arg) return arg.split('=')[1];
+    
+    // Try npm environment variable
+    const envVarName = `npm_config_${argName.replace(/^--/, '').replace(/-/g, '_')}`;
+    const envValue = process.env[envVarName];
+    if (envValue && envValue !== 'true' && envValue !== 'false') {
+      return envValue;
+    }
+    
+    return undefined;
   }
 
   /**
    * Parse boolean CLI arguments (e.g., --debug-screenshots=false)
+   * Handles npm environment variables as well
    */
   private parseCliBoolean(argName: string, defaultValue: boolean): boolean {
     const value = this.getCliArgValue(argName);
-    if (value === undefined) return defaultValue;
-    return value === 'true' || value === '1';
+    if (value !== undefined) {
+      return value === 'true' || value === '1';
+    }
+    
+    // Check npm environment variable for boolean flags
+    const envVarName = `npm_config_${argName.replace(/^--/, '').replace(/-/g, '_')}`;
+    const envValue = process.env[envVarName];
+    if (envValue !== undefined) {
+      return envValue === 'true' || envValue === '';  // npm sets empty string for boolean flags
+    }
+    
+    return defaultValue;
   }
 }

--- a/src/debug/debug-config.ts
+++ b/src/debug/debug-config.ts
@@ -54,10 +54,26 @@ export class DebugConfigManager {
    * Check if debug mode is enabled via CLI argument or environment variable
    * Handles npm's conversion of --debug-mode to --debug_mode and npm_config_debug_mode
    */
+  /**
+   * Helper to check if a CLI argument (hyphen/underscore variants) or its npm config env var is set to true
+   */
+  private isCliArgOrNpmConfigTrue(argName: string): boolean {
+    const hyphenArg = argName;
+    const underscoreArg = argName.replace(/-/g, '_');
+    const npmConfigVar = this.getNpmConfigVarName(argName);
+    // Check CLI args
+    if (process.argv.includes(hyphenArg) || process.argv.includes(underscoreArg)) {
+      return true;
+    }
+    // Check npm config env var
+    if (process.env[npmConfigVar] === 'true') {
+      return true;
+    }
+    return false;
+  }
+
   private isDebugModeEnabled(): boolean {
-    return process.argv.includes('--debug-mode') || 
-           process.argv.includes('--debug_mode') ||
-           process.env.npm_config_debug_mode === 'true';
+    return this.isCliArgOrNpmConfigTrue('--debug-mode');
   }
 
   /**

--- a/src/debug/debug-config.ts
+++ b/src/debug/debug-config.ts
@@ -1,0 +1,88 @@
+export interface DebugConfig {
+  enabled: boolean;
+  logLevel: 'verbose' | 'detailed' | 'minimal';
+  captureScreenshots: boolean;
+  captureDomSnapshots: boolean;
+  trackNetworkRequests: boolean;
+  logElementInteractions: boolean;
+  outputFormat: 'json' | 'structured-text';
+}
+
+/**
+ * Centralized configuration manager for test debugging features.
+ * Activated by --debug-mode CLI argument or DEBUG_MODE=1 environment variable.
+ */
+export class DebugConfigManager {
+  private static instance: DebugConfigManager;
+  private config: DebugConfig;
+
+  private constructor() {
+    // Check for debug mode activation via CLI argument
+    const isDebugEnabled = process.argv.includes('--debug-mode');
+
+    this.config = {
+      enabled: isDebugEnabled,
+      logLevel: this.parseLogLevel(this.getCliArgValue('--debug-level')) || 'detailed',
+      captureScreenshots: this.parseCliBoolean('--debug-screenshots', true),
+      captureDomSnapshots: this.parseCliBoolean('--debug-dom-snapshots', true),
+      trackNetworkRequests: this.parseCliBoolean('--debug-network', false),
+      logElementInteractions: this.parseCliBoolean('--debug-elements', true),
+      outputFormat: this.parseOutputFormat(this.getCliArgValue('--debug-format')) || 'structured-text'
+    };
+
+    if (this.config.enabled) {
+      console.log('[DEBUG] Debug mode activated with configuration:', JSON.stringify(this.config, null, 2));
+    }
+  }
+
+  static getInstance(): DebugConfigManager {
+    if (!this.instance) {
+      this.instance = new DebugConfigManager();
+    }
+    return this.instance;
+  }
+
+  getConfig(): DebugConfig {
+    return { ...this.config };
+  }
+
+  isDebugEnabled(): boolean {
+    return this.config.enabled;
+  }
+
+  private parseLogLevel(value?: string): 'verbose' | 'detailed' | 'minimal' | undefined {
+    if (!value) return undefined;
+    const normalized = value.toLowerCase();
+    if (['verbose', 'detailed', 'minimal'].includes(normalized)) {
+      return normalized as 'verbose' | 'detailed' | 'minimal';
+    }
+    return undefined;
+  }
+
+  private parseOutputFormat(value?: string): 'json' | 'structured-text' | undefined {
+    if (!value) return undefined;
+    const normalized = value.toLowerCase();
+    if (['json', 'structured-text'].includes(normalized)) {
+      return normalized as 'json' | 'structured-text';
+    }
+    return undefined;
+  }
+
+  /**
+   * Get the value of a CLI argument (e.g., --debug-level=verbose)
+   */
+  private getCliArgValue(argName: string): string | undefined {
+    const argWithEquals = `${argName}=`;
+    const arg = process.argv.find(arg => arg.startsWith(argWithEquals));
+    return arg ? arg.split('=')[1] : undefined;
+  }
+
+  /**
+   * Parse boolean CLI arguments (e.g., --debug-screenshots=false)
+   */
+  private parseCliBoolean(argName: string, defaultValue: boolean): boolean {
+    const value = this.getCliArgValue(argName);
+    if (value === undefined) return defaultValue;
+    return value === 'true' || value === '1';
+  }
+}

--- a/src/debug/debug-example.test.ts
+++ b/src/debug/debug-example.test.ts
@@ -1,0 +1,72 @@
+import { By } from 'selenium-webdriver';
+import { BaseSeleniumTest } from '../../tests/base-selenium-test';
+import { DebugConfigManager } from './debug-config';
+
+/**
+ * Example test demonstrating the debug toolset functionality.
+ * Run with: npm test -- --file=src/debug/debug-example.test.ts --debug-mode
+ */
+
+async function debugExampleTest() {
+  const test = new BaseSeleniumTest('debug-example');
+  
+  try {
+    await test.start();
+    
+    const debugConfig = DebugConfigManager.getInstance().getConfig();
+    console.log('[EXAMPLE] Debug mode enabled:', debugConfig.enabled);
+    
+    if (debugConfig.enabled) {
+      console.log('[EXAMPLE] Debug configuration:', JSON.stringify(debugConfig, null, 2));
+    }
+    
+    // Navigate to a test page
+    await test.driver!.get('https://example.com');
+    
+    // Debug helper usage examples (only when debug mode is enabled)
+    if (debugConfig.enabled && test.debugHelper) {
+      await test.debugHelper.logPageState('after_navigation');
+      await test.debugHelper.captureDomSnapshot('initial_page');
+      await test.debugHelper.logElementsFound('h1', 1);
+    }
+    
+    // Try to find and interact with elements
+    try {
+      await test.waitForElement(By.css('h1'));
+      console.log('[EXAMPLE] Found h1 element successfully');
+    } catch (e) {
+      console.log('[EXAMPLE] Failed to find h1 element');
+    }
+    
+    // Demonstrate element analysis
+    if (debugConfig.enabled && test.debugHelper) {
+      await test.debugHelper.analyzeElementInteraction('h1', 'click');
+    }
+    
+    // Try clicking a non-existent element to demonstrate error debugging
+    try {
+      await test.clickElement(By.css('.non-existent-button'));
+    } catch (e) {
+      console.log('[EXAMPLE] Expected error - element not found');
+    }
+    
+    // Demonstrate advanced wait debugging
+    if (debugConfig.enabled && test.debugHelper) {
+      await test.debugHelper.waitAndDebug('.another-non-existent-element', 2000);
+    }
+    
+    console.log('[EXAMPLE] Test completed successfully');
+    await test.finish(true);
+    
+  } catch (error) {
+    console.error('[EXAMPLE] Test failed:', error);
+    await test.handleError(error);
+  }
+}
+
+// Only run if this file is executed directly
+if (require.main === module) {
+  console.log('[EXAMPLE] Starting debug example test...');
+  console.log('[EXAMPLE] To see debug output, run with: npm test -- --file=src/debug/debug-example.test.ts --debug-mode');
+  debugExampleTest();
+}

--- a/src/debug/debug-helper.ts
+++ b/src/debug/debug-helper.ts
@@ -122,7 +122,8 @@ export class DebugHelper {
       
       // Gather detailed information about found elements
       const elementDetails = await Promise.all(
-        elements.slice(0, MAX_ELEMENTS_TO_ANALYZE).map(async (el, i) => { // Limit to first elements for analysis
+        // Limit to first MAX_ELEMENTS_TO_ANALYZE (10) elements for performance
+        elements.slice(0, MAX_ELEMENTS_TO_ANALYZE).map(async (el, i) => {
           try {
             const tagName = await el.getTagName();
             const text = await el.getText();

--- a/src/debug/debug-helper.ts
+++ b/src/debug/debug-helper.ts
@@ -1,0 +1,432 @@
+import { WebDriver, By, WebElement } from 'selenium-webdriver';
+import { DebugLogger } from './debug-logger';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Advanced debugging utilities for Selenium tests.
+ * Provides DOM snapshots, page state logging, and element analysis.
+ */
+export class DebugHelper {
+  constructor(private driver: WebDriver, private logger: DebugLogger) {}
+
+  /**
+   * Capture a complete DOM snapshot at a specific step
+   */
+  async captureDomSnapshot(stepName: string): Promise<string | undefined> {
+    try {
+      // Check if browser session is still alive before attempting DOM capture
+      await this.driver.getCurrentUrl();
+      
+      const html = await this.driver.getPageSource();
+      const timestamp = Date.now();
+      const filename = `dom_${stepName}_${timestamp}.html`;
+      const filepath = path.join(this.logger.debugDir, filename);
+      
+      // Add some debugging metadata to the HTML
+      const debugMetadata = `<!-- DOM Snapshot captured at: ${new Date().toISOString()} for step: ${stepName} -->\n`;
+      const fullHtml = debugMetadata + html;
+      
+      fs.writeFileSync(filepath, fullHtml, 'utf8');
+      
+      this.logger.log({
+        action: 'dom_snapshot',
+        success: true,
+        context: {
+          step: stepName,
+          filePath: path.basename(filepath),
+          htmlLength: html.length
+        }
+      });
+      
+      return filepath;
+    } catch (e) {
+      const error = e instanceof Error ? e.message : String(e);
+      console.warn(`[DEBUG] Failed to capture DOM snapshot for step '${stepName}':`, error);
+      
+      this.logger.log({
+        action: 'dom_snapshot',
+        success: false,
+        error,
+        context: { step: stepName }
+      });
+      
+      return undefined;
+    }
+  }
+
+  /**
+   * Log comprehensive page state information
+   */
+  async logPageState(stepName: string): Promise<void> {
+    try {
+      // Check if browser session is still alive before attempting page state capture
+      await this.driver.getCurrentUrl();
+      
+      const url = await this.driver.getCurrentUrl();
+      const title = await this.driver.getTitle();
+      const windowSize = await this.driver.manage().window().getRect();
+      
+      // Get additional browser information
+      const userAgent = await this.driver.executeScript('return navigator.userAgent;') as string;
+      const pageLoadState = await this.driver.executeScript('return document.readyState;') as string;
+      
+      // Get viewport information
+      const viewportInfo = await this.driver.executeScript(`
+        return {
+          innerWidth: window.innerWidth,
+          innerHeight: window.innerHeight,
+          scrollX: window.scrollX,
+          scrollY: window.scrollY,
+          devicePixelRatio: window.devicePixelRatio
+        };
+      `) as any;
+      
+      this.logger.log({
+        action: 'page_state',
+        success: true,
+        context: {
+          step: stepName,
+          url,
+          title,
+          windowSize,
+          userAgent,
+          pageLoadState,
+          viewport: viewportInfo
+        }
+      });
+    } catch (e) {
+      const error = e instanceof Error ? e.message : String(e);
+      console.warn(`[DEBUG] Failed to log page state for step '${stepName}':`, error);
+      
+      this.logger.log({
+        action: 'page_state',
+        success: false,
+        error,
+        context: { step: stepName }
+      });
+    }
+  }
+
+  /**
+   * Log information about elements found with a given locator
+   */
+  async logElementsFound(locator: string, expectedCount?: number): Promise<void> {
+    try {
+      const elements = await this.driver.findElements(By.css(locator));
+      const actualCount = elements.length;
+      
+      // Gather detailed information about found elements
+      const elementDetails = await Promise.all(
+        elements.slice(0, 10).map(async (el, i) => { // Limit to first 10 elements
+          try {
+            const tagName = await el.getTagName();
+            const text = await el.getText();
+            const isVisible = await el.isDisplayed();
+            const isEnabled = await el.isEnabled();
+            const rect = await el.getRect();
+            
+            // Get key attributes
+            const attributes: { [key: string]: string | null } = {};
+            const commonAttrs = ['id', 'class', 'name', 'type', 'value', 'href', 'src', 'alt'];
+            for (const attr of commonAttrs) {
+              attributes[attr] = await el.getAttribute(attr);
+            }
+            
+            return {
+              index: i,
+              tagName,
+              text: text.substring(0, 100), // Limit text length
+              isVisible,
+              isEnabled,
+              rect,
+              attributes: Object.fromEntries(
+                Object.entries(attributes).filter(([, value]) => value !== null && value !== '')
+              )
+            };
+          } catch (elementError) {
+            return {
+              index: i,
+              error: elementError instanceof Error ? elementError.message : String(elementError)
+            };
+          }
+        })
+      );
+      
+      this.logger.log({
+        action: 'elements_found',
+        element: locator,
+        success: expectedCount ? actualCount === expectedCount : actualCount > 0,
+        context: {
+          expectedCount,
+          actualCount,
+          elements: elementDetails,
+          truncated: elements.length > 10
+        }
+      });
+    } catch (e) {
+      const error = e instanceof Error ? e.message : String(e);
+      console.warn(`[DEBUG] Failed to log elements found for locator '${locator}':`, error);
+      
+      this.logger.log({
+        action: 'elements_found',
+        element: locator,
+        success: false,
+        error,
+        context: { expectedCount }
+      });
+    }
+  }
+
+  /**
+   * Advanced wait with detailed debugging information
+   */
+  async waitAndDebug(locator: string, timeoutMs: number = 10000): Promise<WebElement | null> {
+    const startTime = Date.now();
+    let found = false;
+    let element: WebElement | null = null;
+    let attempts = 0;
+    
+    this.logger.log({
+      action: 'wait_debug_start',
+      element: locator,
+      success: true,
+      context: {
+        timeoutMs,
+        startTime: new Date(startTime).toISOString()
+      }
+    });
+    
+    while (Date.now() - startTime < timeoutMs && !found) {
+      attempts++;
+      
+      try {
+        const elements = await this.driver.findElements(By.css(locator));
+        if (elements.length > 0) {
+          element = elements[0];
+          found = true;
+          
+          // Log successful find with element details
+          const isVisible = await element.isDisplayed();
+          const isEnabled = await element.isEnabled();
+          const rect = await element.getRect();
+          
+          this.logger.log({
+            action: 'wait_debug_success',
+            element: locator,
+            success: true,
+            duration: Date.now() - startTime,
+            context: {
+              attempts,
+              elementsFound: elements.length,
+              isVisible,
+              isEnabled,
+              rect
+            }
+          });
+          
+          return element;
+        } else {
+          // Log attempt details
+          if (attempts % 5 === 0) { // Log every 5th attempt to avoid spam
+            await this.logPageState(`wait_attempt_${attempts}`);
+            
+            this.logger.log({
+              action: 'wait_debug_attempt',
+              element: locator,
+              success: false,
+              context: {
+                attempt: attempts,
+                elapsed: Date.now() - startTime,
+                elementsFound: 0
+              }
+            });
+          }
+          
+          await new Promise(resolve => setTimeout(resolve, 500));
+        }
+      } catch (e) {
+        const error = e instanceof Error ? e.message : String(e);
+        this.logger.log({
+          action: 'wait_debug_error',
+          element: locator,
+          success: false,
+          error,
+          context: {
+            attempt: attempts,
+            elapsed: Date.now() - startTime
+          }
+        });
+        
+        await new Promise(resolve => setTimeout(resolve, 500));
+      }
+    }
+    
+    if (!found) {
+      // Final failure - capture comprehensive debug information
+      const domSnapshot = await this.captureDomSnapshot('wait_timeout');
+      await this.logPageState('wait_timeout');
+      await this.logElementsFound(locator);
+      
+      this.logger.log({
+        action: 'wait_debug_timeout',
+        element: locator,
+        success: false,
+        duration: Date.now() - startTime,
+        context: {
+          timeoutMs,
+          attempts,
+          domSnapshot: domSnapshot ? path.basename(domSnapshot) : undefined
+        }
+      });
+    }
+    
+    return element;
+  }
+
+  /**
+   * Analyze and debug element interaction issues
+   */
+  async analyzeElementInteraction(locator: string, interaction: string): Promise<void> {
+    try {
+      const elements = await this.driver.findElements(By.css(locator));
+      
+      if (elements.length === 0) {
+        this.logger.log({
+          action: 'analyze_element',
+          element: locator,
+          success: false,
+          context: {
+            interaction,
+            issue: 'Element not found',
+            elementsCount: 0
+          }
+        });
+        return;
+      }
+      
+      const element = elements[0];
+      
+      // Comprehensive element analysis
+      const isDisplayed = await element.isDisplayed();
+      const isEnabled = await element.isEnabled();
+      const rect = await element.getRect();
+      const tagName = await element.getTagName();
+      const text = await element.getText();
+      
+      // Check if element is in viewport
+      const inViewport = await this.driver.executeScript(`
+        const rect = arguments[0].getBoundingClientRect();
+        return (
+          rect.top >= 0 &&
+          rect.left >= 0 &&
+          rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+          rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+        );
+      `, element) as boolean;
+      
+      // Check for overlapping elements
+      const isClickable = await this.driver.executeScript(`
+        const element = arguments[0];
+        const rect = element.getBoundingClientRect();
+        const centerX = rect.left + rect.width / 2;
+        const centerY = rect.top + rect.height / 2;
+        const elementAtPoint = document.elementFromPoint(centerX, centerY);
+        return elementAtPoint === element || element.contains(elementAtPoint);
+      `, element) as boolean;
+      
+      // Get computed styles that might affect interaction
+      const computedStyles = await this.driver.executeScript(`
+        const styles = window.getComputedStyle(arguments[0]);
+        return {
+          display: styles.display,
+          visibility: styles.visibility,
+          opacity: styles.opacity,
+          pointerEvents: styles.pointerEvents,
+          position: styles.position,
+          zIndex: styles.zIndex
+        };
+      `, element) as any;
+      
+      const analysis = {
+        interaction,
+        elementsFound: elements.length,
+        isDisplayed,
+        isEnabled,
+        inViewport,
+        isClickable,
+        rect,
+        tagName,
+        textContent: text.substring(0, 100),
+        computedStyles
+      };
+      
+      // Determine potential issues
+      const issues: string[] = [];
+      if (!isDisplayed) issues.push('Element not displayed');
+      if (!isEnabled) issues.push('Element not enabled');
+      if (!inViewport) issues.push('Element not in viewport');
+      if (!isClickable) issues.push('Element not clickable (covered by another element)');
+      if (computedStyles.pointerEvents === 'none') issues.push('Pointer events disabled');
+      if (computedStyles.opacity === '0') issues.push('Element has opacity 0');
+      if (computedStyles.visibility === 'hidden') issues.push('Element visibility hidden');
+      
+      this.logger.log({
+        action: 'analyze_element',
+        element: locator,
+        success: issues.length === 0,
+        context: {
+          ...analysis,
+          issues: issues.length > 0 ? issues : undefined
+        }
+      });
+    } catch (e) {
+      const error = e instanceof Error ? e.message : String(e);
+      this.logger.log({
+        action: 'analyze_element',
+        element: locator,
+        success: false,
+        error,
+        context: { interaction }
+      });
+    }
+  }
+
+  /**
+   * Capture console logs from the browser
+   */
+  async captureConsoleLogs(stepName: string): Promise<void> {
+    try {
+      const logs = await this.driver.manage().logs().get('browser');
+      const formattedLogs = logs.map(log => ({
+        level: log.level.name,
+        message: log.message,
+        timestamp: new Date(log.timestamp).toISOString()
+      }));
+      
+      if (formattedLogs.length > 0) {
+        const logsFile = path.join(this.logger.debugDir, `console_${stepName}_${Date.now()}.json`);
+        fs.writeFileSync(logsFile, JSON.stringify(formattedLogs, null, 2));
+      }
+      
+      this.logger.log({
+        action: 'console_logs',
+        success: true,
+        context: {
+          step: stepName,
+          logCount: formattedLogs.length,
+          errors: formattedLogs.filter(log => log.level === 'SEVERE').length,
+          warnings: formattedLogs.filter(log => log.level === 'WARNING').length
+        }
+      });
+    } catch (e) {
+      // Console logs might not be available in all drivers/modes
+      this.logger.log({
+        action: 'console_logs',
+        success: false,
+        error: 'Console logs not available',
+        context: { step: stepName }
+      });
+    }
+  }
+}

--- a/src/debug/debug-helper.ts
+++ b/src/debug/debug-helper.ts
@@ -3,6 +3,10 @@ import { DebugLogger } from './debug-logger';
 import * as fs from 'fs';
 import * as path from 'path';
 
+// Configuration constants for debugging behavior
+const MAX_ELEMENTS_TO_ANALYZE = 10;
+const LOG_ATTEMPT_INTERVAL = 5;
+
 /**
  * Advanced debugging utilities for Selenium tests.
  * Provides DOM snapshots, page state logging, and element analysis.
@@ -118,7 +122,7 @@ export class DebugHelper {
       
       // Gather detailed information about found elements
       const elementDetails = await Promise.all(
-        elements.slice(0, 10).map(async (el, i) => { // Limit to first 10 elements
+        elements.slice(0, MAX_ELEMENTS_TO_ANALYZE).map(async (el, i) => { // Limit to first elements for analysis
           try {
             const tagName = await el.getTagName();
             const text = await el.getText();
@@ -228,7 +232,7 @@ export class DebugHelper {
           return element;
         } else {
           // Log attempt details
-          if (attempts % 5 === 0) { // Log every 5th attempt to avoid spam
+          if (attempts % LOG_ATTEMPT_INTERVAL === 0) { // Log at regular intervals to avoid spam
             await this.logPageState(`wait_attempt_${attempts}`);
             
             this.logger.log({

--- a/src/debug/debug-logger.ts
+++ b/src/debug/debug-logger.ts
@@ -228,10 +228,11 @@ export class DebugLogger {
     // Pre-compute JSON stringifications to avoid repeated operations
     const failureContext = failure.context ? JSON.stringify(failure.context, null, 2) : 'None';
     
-    // Pre-compute context log entries
+    // Pre-compute stringified contexts for context log entries
+    const stringifiedContexts = context.map(entry => entry.context ? JSON.stringify(entry.context) : '');
     const contextLogEntries = context.map((entry, index) => {
       const prefix = entry === failure ? '❌ FAILURE →' : `${index + 1}.`;
-      const contextStr = entry.context ? ` | CONTEXT: ${JSON.stringify(entry.context)}` : '';
+      const contextStr = stringifiedContexts[index] ? ` | CONTEXT: ${stringifiedContexts[index]}` : '';
       const errorStr = entry.error ? ` | ERROR: ${entry.error}` : '';
       return `${prefix} [${entry.timestamp}] ACTION: ${entry.action} | SUCCESS: ${entry.success} | ELEMENT: ${entry.element || 'N/A'} | DURATION: ${entry.duration || 0}ms${errorStr}${contextStr}`;
     }).join('\n');

--- a/src/debug/debug-logger.ts
+++ b/src/debug/debug-logger.ts
@@ -1,0 +1,372 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface DebugLogEntry {
+  timestamp: string;
+  testName: string;
+  action: string;
+  element?: string;
+  success: boolean;
+  duration?: number;
+  screenshot?: string;
+  domSnapshot?: string;
+  networkRequests?: any[];
+  error?: string;
+  context?: any;
+}
+
+export interface DebugReport {
+  testName: string;
+  startTime?: string;
+  endTime?: string;
+  totalActions: number;
+  failures: number;
+  duration: number;
+  entries: DebugLogEntry[];
+  summary: {
+    actions: { [action: string]: number };
+    failures: { [action: string]: number };
+    averageDuration: { [action: string]: number };
+  };
+}
+
+/**
+ * Specialized logger for test debugging that outputs AI-parseable structured logs.
+ * Creates both real-time log files and comprehensive debug reports.
+ */
+export class DebugLogger {
+  private logEntries: DebugLogEntry[] = [];
+  private testName: string;
+  public debugDir: string;
+  private startTime?: Date;
+
+  constructor(testName: string) {
+    this.testName = testName;
+    
+    // Create debug directory structure
+    const baseDebugDir = path.join(process.cwd(), 'test-results', 'debug-logs');
+    this.debugDir = path.join(baseDebugDir, testName);
+    
+    if (!fs.existsSync(this.debugDir)) {
+      fs.mkdirSync(this.debugDir, { recursive: true });
+    }
+
+    this.startTime = new Date();
+    console.log(`[DEBUG] Debug logging initialized for test: ${testName}`);
+    console.log(`[DEBUG] Debug files will be saved to: ${this.debugDir}`);
+  }
+
+  /**
+   * Log a debug entry with structured information
+   */
+  log(entry: Partial<DebugLogEntry>): void {
+    const fullEntry: DebugLogEntry = {
+      timestamp: new Date().toISOString(),
+      testName: this.testName,
+      action: entry.action || 'unknown',
+      success: entry.success ?? true,
+      ...entry
+    };
+    
+    this.logEntries.push(fullEntry);
+    
+    // Real-time append to structured log file for immediate debugging
+    const logLine = this.formatLogEntry(fullEntry);
+    const logFile = path.join(this.debugDir, 'debug.log');
+    
+    try {
+      fs.appendFileSync(logFile, logLine + '\n');
+    } catch (error) {
+      console.warn(`[DEBUG] Failed to write to debug log: ${error}`);
+    }
+  }
+
+  /**
+   * Format log entry in AI-parseable structured format
+   */
+  private formatLogEntry(entry: DebugLogEntry): string {
+    const parts = [
+      `[${entry.timestamp}]`,
+      `ACTION: ${entry.action}`,
+      `SUCCESS: ${entry.success}`,
+      `ELEMENT: ${entry.element || 'N/A'}`,
+      `DURATION: ${entry.duration || 0}ms`
+    ];
+
+    if (entry.error) {
+      parts.push(`ERROR: ${entry.error}`);
+    }
+
+    if (entry.screenshot) {
+      parts.push(`SCREENSHOT: ${path.basename(entry.screenshot)}`);
+    }
+
+    if (entry.domSnapshot) {
+      parts.push(`DOM_SNAPSHOT: ${path.basename(entry.domSnapshot)}`);
+    }
+
+    if (entry.context) {
+      try {
+        parts.push(`CONTEXT: ${JSON.stringify(entry.context)}`);
+      } catch (e) {
+        parts.push(`CONTEXT: [Unable to serialize context]`);
+      }
+    }
+
+    return parts.join(' | ');
+  }
+
+  /**
+   * Generate comprehensive debug report with analytics
+   */
+  async saveDebugReport(): Promise<void> {
+    if (this.logEntries.length === 0) {
+      console.warn('[DEBUG] No log entries to save in debug report');
+      return;
+    }
+
+    const endTime = new Date();
+    const startEntry = this.logEntries[0];
+    const endEntry = this.logEntries[this.logEntries.length - 1];
+    
+    const report: DebugReport = {
+      testName: this.testName,
+      startTime: startEntry?.timestamp,
+      endTime: endEntry?.timestamp,
+      totalActions: this.logEntries.length,
+      failures: this.logEntries.filter(e => !e.success).length,
+      duration: this.startTime ? endTime.getTime() - this.startTime.getTime() : 0,
+      entries: this.logEntries,
+      summary: this.generateSummary()
+    };
+
+    // Save JSON report
+    const reportFile = path.join(this.debugDir, 'debug-report.json');
+    try {
+      fs.writeFileSync(reportFile, JSON.stringify(report, null, 2));
+      console.log(`[DEBUG] Debug report saved to: ${reportFile}`);
+    } catch (error) {
+      console.error(`[DEBUG] Failed to save debug report: ${error}`);
+    }
+
+    // Save human-readable summary
+    const summaryFile = path.join(this.debugDir, 'debug-summary.md');
+    try {
+      fs.writeFileSync(summaryFile, this.generateMarkdownSummary(report));
+      console.log(`[DEBUG] Debug summary saved to: ${summaryFile}`);
+    } catch (error) {
+      console.error(`[DEBUG] Failed to save debug summary: ${error}`);
+    }
+
+    // Auto-generate AI analysis request for failures
+    await this.generateAIAnalysisRequest();
+  }
+
+  /**
+   * Generate an AI-ready analysis request for test failures
+   */
+  async generateAIAnalysisRequest(): Promise<void> {
+    const failures = this.logEntries.filter(e => !e.success);
+    if (failures.length === 0) {
+      return; // No failures to analyze
+    }
+
+    const lastFailure = failures[failures.length - 1];
+    const contextEntries = this.logEntries.slice(
+      Math.max(0, this.logEntries.indexOf(lastFailure) - 3),
+      this.logEntries.indexOf(lastFailure) + 1
+    );
+
+    const analysisRequest = this.formatAIAnalysisRequest(lastFailure, contextEntries, failures);
+    
+    try {
+      const aiRequestFile = path.join(this.debugDir, 'ai-analysis-request.md');
+      fs.writeFileSync(aiRequestFile, analysisRequest);
+      
+      console.log(`[DEBUG] AI analysis request generated: ${aiRequestFile}`);
+      console.log('[DEBUG] Copy the contents of ai-analysis-request.md to your AI assistant for analysis');
+    } catch (error) {
+      console.error(`[DEBUG] Failed to generate AI analysis request: ${error}`);
+    }
+  }
+
+  /**
+   * Format an AI-ready analysis request
+   */
+  private formatAIAnalysisRequest(failure: DebugLogEntry, context: DebugLogEntry[], allFailures: DebugLogEntry[]): string {
+    const failureIndex = this.logEntries.indexOf(failure);
+    const testDuration = this.startTime ? new Date().getTime() - this.startTime.getTime() : 0;
+
+    let markdown = `# Test Failure Analysis Request
+
+## Test Information
+- **Test Name:** ${this.testName}
+- **Total Test Duration:** ${testDuration}ms
+- **Total Actions:** ${this.logEntries.length}
+- **Total Failures:** ${allFailures.length}
+- **Failure Time:** ${failure.timestamp}
+- **Failed Action:** ${failure.action}
+- **Element:** ${failure.element || 'N/A'}
+- **Error:** ${failure.error || 'Unknown error'}
+
+## Primary Failure Details
+- **Duration:** ${failure.duration || 0}ms
+- **Success:** ${failure.success}
+- **Context:** ${failure.context ? JSON.stringify(failure.context, null, 2) : 'None'}
+
+## Debug Log Context (Last 4 Actions Leading to Failure)
+\`\`\`
+${context.map((entry, index) => {
+  const prefix = entry === failure ? '❌ FAILURE →' : `${index + 1}.`;
+  return `${prefix} [${entry.timestamp}] ACTION: ${entry.action} | SUCCESS: ${entry.success} | ELEMENT: ${entry.element || 'N/A'} | DURATION: ${entry.duration || 0}ms${entry.error ? ` | ERROR: ${entry.error}` : ''}${entry.context ? ` | CONTEXT: ${JSON.stringify(entry.context)}` : ''}`;
+}).join('\n')}
+\`\`\`
+
+## Available Debug Artifacts
+${failure.screenshot ? `- **Screenshot:** ${path.basename(failure.screenshot)}` : ''}
+${failure.domSnapshot ? `- **DOM Snapshot:** ${path.basename(failure.domSnapshot)}` : ''}
+- **Full Debug Log:** debug.log
+- **Debug Report:** debug-report.json
+- **Debug Summary:** debug-summary.md
+
+`;
+
+    // Add multiple failures analysis if applicable
+    if (allFailures.length > 1) {
+      markdown += `## Multiple Failures Detected (${allFailures.length} total)
+${allFailures.map((f, i) => `${i + 1}. **${f.action}** at ${f.timestamp} - ${f.error || 'Unknown error'}`).join('\n')}
+
+`;
+    }
+
+    // Add timing analysis
+    if (failure.duration && failure.duration > 5000) {
+      markdown += `## ⚠️ Performance Issue Detected
+This action took ${failure.duration}ms, which is unusually long and may indicate:
+- Network connectivity issues
+- Element loading problems
+- Timing/synchronization issues
+
+`;
+    }
+
+    markdown += `## Questions for AI Analysis
+1. **Root Cause:** What is the primary cause of this failure?
+2. **Fix Strategy:** What specific steps should I take to fix this issue?
+3. **Race Conditions:** Are there any timing issues or race conditions evident?
+4. **Locator Strategy:** Should I modify the element locator strategy?
+5. **Best Practices:** What best practices should I implement to prevent this type of failure?
+6. **Test Stability:** How can I make this test more reliable?
+
+## Additional Context
+Please analyze the debug information above and provide:
+- Specific, actionable recommendations for fixing this test failure
+- Code examples if applicable
+- Suggestions for improving test reliability
+- Any patterns you notice that could indicate broader issues
+
+---
+*Generated automatically by Decent UI Automation Debug Toolset*`;
+
+    return markdown;
+  }
+
+  /**
+   * Generate analytics summary of test execution
+   */
+  private generateSummary(): DebugReport['summary'] {
+    const actions: { [action: string]: number } = {};
+    const failures: { [action: string]: number } = {};
+    const durations: { [action: string]: number[] } = {};
+
+    this.logEntries.forEach(entry => {
+      // Count actions
+      actions[entry.action] = (actions[entry.action] || 0) + 1;
+
+      // Count failures
+      if (!entry.success) {
+        failures[entry.action] = (failures[entry.action] || 0) + 1;
+      }
+
+      // Track durations
+      if (entry.duration !== undefined) {
+        if (!durations[entry.action]) {
+          durations[entry.action] = [];
+        }
+        durations[entry.action].push(entry.duration);
+      }
+    });
+
+    // Calculate average durations
+    const averageDuration: { [action: string]: number } = {};
+    Object.keys(durations).forEach(action => {
+      const actionDurations = durations[action];
+      if (actionDurations.length > 0) {
+        averageDuration[action] = Math.round(
+          actionDurations.reduce((sum, duration) => sum + duration, 0) / actionDurations.length
+        );
+      }
+    });
+
+    return { actions, failures, averageDuration };
+  }
+
+  /**
+   * Generate human-readable markdown summary
+   */
+  private generateMarkdownSummary(report: DebugReport): string {
+    const { summary } = report;
+    
+    let markdown = `# Debug Report: ${report.testName}\n\n`;
+    markdown += `**Test Duration:** ${report.duration}ms\n`;
+    markdown += `**Total Actions:** ${report.totalActions}\n`;
+    markdown += `**Failures:** ${report.failures}\n`;
+    markdown += `**Start Time:** ${report.startTime}\n`;
+    markdown += `**End Time:** ${report.endTime}\n\n`;
+
+    markdown += `## Action Summary\n\n`;
+    markdown += `| Action | Count | Failures | Avg Duration (ms) |\n`;
+    markdown += `|--------|-------|----------|------------------|\n`;
+    
+    Object.keys(summary.actions).forEach(action => {
+      const count = summary.actions[action];
+      const failureCount = summary.failures[action] || 0;
+      const avgDuration = summary.averageDuration[action] || 0;
+      markdown += `| ${action} | ${count} | ${failureCount} | ${avgDuration} |\n`;
+    });
+
+    if (report.failures > 0) {
+      markdown += `\n## Failures\n\n`;
+      const failedEntries = report.entries.filter(e => !e.success);
+      failedEntries.forEach((entry, index) => {
+        markdown += `### Failure ${index + 1}: ${entry.action}\n`;
+        markdown += `- **Time:** ${entry.timestamp}\n`;
+        markdown += `- **Element:** ${entry.element || 'N/A'}\n`;
+        markdown += `- **Error:** ${entry.error || 'Unknown error'}\n`;
+        if (entry.screenshot) {
+          markdown += `- **Screenshot:** ${path.basename(entry.screenshot)}\n`;
+        }
+        if (entry.domSnapshot) {
+          markdown += `- **DOM Snapshot:** ${path.basename(entry.domSnapshot)}\n`;
+        }
+        markdown += `\n`;
+      });
+    }
+
+    return markdown;
+  }
+
+  /**
+   * Get total number of logged entries
+   */
+  getEntryCount(): number {
+    return this.logEntries.length;
+  }
+
+  /**
+   * Get number of failed entries
+   */
+  getFailureCount(): number {
+    return this.logEntries.filter(e => !e.success).length;
+  }
+}

--- a/tests/base-selenium-test.ts
+++ b/tests/base-selenium-test.ts
@@ -66,6 +66,21 @@ export class BaseSeleniumTest {
   }
 
   /**
+   * Check if browser session is still alive
+   * Useful for preventing errors when browser has crashed or been closed
+   */
+  private async isBrowserSessionAlive(): Promise<boolean> {
+    if (!this.driver) return false;
+    
+    try {
+      await this.driver.getCurrentUrl();
+      return true;
+    } catch (sessionError) {
+      return false;
+    }
+  }
+
+  /**
    * Clean up Chrome temporary files and directories
    */
   private cleanupChromeTemp(): void {
@@ -180,9 +195,7 @@ export class BaseSeleniumTest {
   async saveScreenshot(timeoutMs = 10000) {
     if (this.driver) {
       // Check if browser session is still alive before attempting screenshot
-      try {
-        await this.driver.getCurrentUrl();
-      } catch (sessionError) {
+      if (!await this.isBrowserSessionAlive()) {
         console.warn('[BaseSeleniumTest] Browser session not available for screenshot, skipping');
         return;
       }

--- a/tests/general/create-dao/erc721-workflow.test.ts
+++ b/tests/general/create-dao/erc721-workflow.test.ts
@@ -35,12 +35,12 @@ BaseSeleniumTest.run(async (test) => {
   // Enter NFT token address
   const tokenAddressInput = await test.waitForElement(By.css('[data-testid="erc721Token.nfts.0.tokenAddressInput"]'));
   await tokenAddressInput.sendKeys('0x31408f226E37FBF8715CA6eE45aaB4Ea213bA7A5');
-  await test.driver!.sleep(1000);
+  await test.driver!.sleep(2000);
   
   // Enter NFT token weight
   const tokenWeightInput = await test.waitForElement(By.css('[data-testid="erc721Token.nfts.0.tokenWeightInput"]'));
-  await tokenWeightInput.sendKeys('1');
-  await test.driver!.sleep(1000);
+  await tokenWeightInput.sendKeys('2');
+  await test.driver!.sleep(2000);
 
   // Click skip next button and wait for next page with retry logic
   const maxRetries = 3;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["tests/**/*.ts", "config/**/*.ts", "run-all-tests.ts"],
+  "include": ["tests/**/*.ts", "config/**/*.ts", "run-all-tests.ts", "src/debug/debug-example.test.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
This adds an optional `--debug` runtime argument that should result in some generic debug logging when running a test that will help when diagnosing a flaky or mysteriously failing test. It may come in handy when creating new tests as well.

One feature that I am hoping will be particularly useful is that this will output a preformatted markdown file with the results meant to be shared with AI.

Essentially, when prompting AI during test debugging, you'd want to:
1. Include the provided markdown file contents in your prompt
2. Indicate that there is more logging information in the test results directory (EX: test-results\debug-logs\debug-example)
3. Explain what is seen in any failure related screenshots